### PR TITLE
Add SharedRef and SharedRwRef to common crate

### DIFF
--- a/crates/matsya-common/src/lib.rs
+++ b/crates/matsya-common/src/lib.rs
@@ -1,3 +1,5 @@
 mod errors;
+mod shared;
 
 pub use errors::*;
+pub use shared::*;

--- a/crates/matsya-common/src/shared.rs
+++ b/crates/matsya-common/src/shared.rs
@@ -1,0 +1,63 @@
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub struct SharedRef<T> {
+    inner: Arc<Mutex<T>>,
+}
+
+impl<T> Default for SharedRef<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(T::default())),
+        }
+    }
+}
+
+impl<T> Clone for SharedRef<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct SharedRwRef<T> {
+    inner: Arc<RwLock<T>>,
+}
+
+impl<T> Default for SharedRwRef<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(T::default())),
+        }
+    }
+}
+
+impl<T> Clone for SharedRwRef<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> SharedRwRef<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
+        }
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<T> {
+        self.inner.read().unwrap()
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<T> {
+        self.inner.write().unwrap()
+    }
+}


### PR DESCRIPTION
This PR aims at the following

- Add `SharedRef` and `SharedRwRef` for common use cases